### PR TITLE
Make it work locally

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,8 +113,8 @@
 
     }
   </style>
-  <script src="https://cdn.socket.io/socket.io-1.2.0.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/es6-shim/0.31.2/es6-shim.js"></script>
+  <script src="./node_modules/es6-shim/es6-shim.js"></script>
+  <script src="./node_modules/socket.io-client/socket.io.js"></script>
 </head>
 <body>
   <div class="container">

--- a/package.json
+++ b/package.json
@@ -3,13 +3,15 @@
   "version": "0.1.0",
   "description": "Pee Wee Rovers for JSConf 2015 (JavaScript Robotics)",
   "dependencies": {
+    "es6-shim": "^0.31.2",
     "express": "latest",
     "galileo-io": "latest",
     "imp-io": "latest",
     "johnny-five": "latest",
     "keypress": "latest",
     "particle-io": "latest",
-    "socket.io": "latest"
+    "socket.io": "latest",
+    "socket.io-client": "^1.3.5"
   },
   "devDependencies": {},
   "scripts": {

--- a/rover-arduino.js
+++ b/rover-arduino.js
@@ -1,12 +1,11 @@
 var five = require("johnny-five");
 var Rover = require("./rover")(five);
-var app = require("express")();
+var express = require("express");
+var app = express();
 var http = require("http").Server(app);
 var io = require("socket.io")(http);
 
-app.get("/", function(req, res) {
-  res.sendFile(__dirname + "/index.html");
-});
+app.use(express.static('./'));
 
 var board = new five.Board();
 

--- a/rover-edison.js
+++ b/rover-edison.js
@@ -1,13 +1,12 @@
 var five = require("johnny-five");
 var Rover = require("./rover")(five);
 var Edison = require("galileo-io");
-var app = require("express")();
+var express = require("express");
+var app = express();
 var http = require("http").Server(app);
 var io = require("socket.io")(http);
 
-app.get("/", function(req, res) {
-  res.sendFile(__dirname + "/index.html");
-});
+app.use(express.static('./'));
 
 var board = new five.Board({
   io: new Edison()

--- a/rover-imp.js
+++ b/rover-imp.js
@@ -1,13 +1,12 @@
 var five = require("johnny-five");
 var Rover = require("./rover")(five);
 var Imp = require("imp-io");
-var app = require("express")();
+var express = require("express");
+var app = express();
 var http = require("http").Server(app);
 var io = require("socket.io")(http);
 
-app.get("/", function(req, res) {
-  res.sendFile(__dirname + "/index.html");
-});
+app.use(express.static('./'));
 
 var board = new five.Board({
   io: new Imp({

--- a/rover-particle.js
+++ b/rover-particle.js
@@ -1,13 +1,11 @@
 var five = require("johnny-five");
 var Rover = require("./rover")(five);
 var Particle = require("particle-io");
-var app = require("express")();
+var app = express();
 var http = require("http").Server(app);
 var io = require("socket.io")(http);
 
-app.get("/", function(req, res) {
-  res.sendFile(__dirname + "/index.html");
-});
+app.use(express.static('./'));
 
 var board = new five.Board({
   io: new Particle({


### PR DESCRIPTION
Instead of loading in es6-shim and socket.io-client from CDNs, load them in locally from npm. This way, after you `npm install`, you won't be required to be connected to the internet to control the rover.
